### PR TITLE
Fix missing enthalpy functions on import

### DIFF
--- a/src/pymser/__init__.py
+++ b/src/pymser/__init__.py
@@ -4,10 +4,13 @@ from .pymser import (exp_decay,
                      calculate_MSEm,
                      MSERm_index,
                      MSERm_LLM_index,
+                     enthalpy_of_adsorption,
                      calc_equilibrated_average,
+                     calc_equilibrated_enthalpy,
                      calc_autocorrelation_time,
                      apply_ADF_test,
-                     equilibrate)
+                     equilibrate,
+                     equilibrate_enthalpy)
 
 __all__ = [exp_decay,
            check_consistency,
@@ -15,6 +18,10 @@ __all__ = [exp_decay,
            calculate_MSEm,
            MSERm_index,
            MSERm_LLM_index,
+           enthalpy_of_adsorption,
            calc_equilibrated_average,
+           calc_equilibrated_enthalpy,
            calc_autocorrelation_time,
-           apply_ADF_test, equilibrate]
+           apply_ADF_test,
+           equilibrate,
+           equilibrate_enthalpy]


### PR DESCRIPTION
# Summary

This PR fix the missing functions related to the enthalpy equilibration on the `__init__`  module.

## Checklist

- [x] I ran the appropriate tests.
- [x] I ran `flake8 --max-line-length=100`.
- [x] I wrote documentation for all new features.
- [x] I have added any new dependencies (libraries and/or tools) to `setup.py`, `Pipfile` and `README.md`.

## Related Issue(s)

Closes #

## Notes to Reviewer

...
