### PR TITLE
Fix some `TypeError`s originating from `numpy` -> `torch` conversion

### DIFF
--- a/src/pymser/pymser.py
+++ b/src/pymser/pymser.py
@@ -86,7 +86,7 @@ def batch_average_data(data, batch_size=1):
     if batch_size > 1:
         # Trucate the data to allow a closed batch.
         # Be aware that this will remove the last points to make a closed batch
-        truncated_data = data[: int(len(data) / batch_size // 1 * batch_size)]
+        truncated_data = data[:int(len(data) / batch_size) * batch_size]
 
         # Reshape the data to create batch of size m.
         reshaped_data = torch.reshape(truncated_data, (-1, batch_size))


### PR DESCRIPTION
# Summary

I observed some errors running the tutorial file, namely

```
File /rwthfs/rz/cluster/work/ab542498/venv/phonon_contribution_pymser/pymser/src/pymser/pymser.py:597, in equilibrate(input_data, LLM, batch_size, ADF_test, uncertainty, print_results)
    594 ac_time, uncorr_samples = calc_autocorrelation_time(equilibrated)
    596 # Calculates the average and standard deviation on the equilibrated data
--> 597 average, avg_uncertainty = calc_equilibrated_average(array_data,
    598                                                      t0,
    599                                                      uncertainty,
    600                                                      ac_time)
    602 # Create a dictionary with the results
    603 results_dict = {'MSE': MSEm_curve,
    604                 't0': t0,
    605                 'average': average,
   (...)
    608                 'ac_time': ac_time,
    609                 'uncorr_samples': uncorr_samples}

File /rwthfs/rz/cluster/work/ab542498/venv/phonon_contribution_pymser/pymser/src/pymser/pymser.py:301, in calc_equilibrated_average(data, eq_index, uncertainty, ac_time)
    298 # Calculate the uncorrelated Standard Error
    299 elif uncertainty == 'uSD':
    300     # Divide the equilibrated_data on uncorrelated chunks
--> 301     uncorr_batches = batch_average_data(equilibrated_data, np.ceil(ac_time).astype(int))
...
---> 87     truncated_data = data[:int(torch.floor(len(data) / batch_size) * batch_size)]
     89     # Reshape the data to create batch of size m.
     90     reshaped_data = torch.reshape(truncated_data, (-1, batch_size))

TypeError: floor(): argument 'input' (position 1) must be Tensor, not numpy.float64
```

and

```
File /rwthfs/rz/cluster/work/ab542498/venv/phonon_contribution_pymser/pymser/src/pymser/pymser.py:597, in equilibrate(input_data, LLM, batch_size, ADF_test, uncertainty, print_results)
    594 ac_time, uncorr_samples = calc_autocorrelation_time(equilibrated)
    596 # Calculates the average and standard deviation on the equilibrated data
--> 597 average, avg_uncertainty = calc_equilibrated_average(array_data,
    598                                                      t0,
    599                                                      uncertainty,
    600                                                      ac_time)
    602 # Create a dictionary with the results
    603 results_dict = {'MSE': MSEm_curve,
    604                 't0': t0,
    605                 'average': average,
   (...)
    608                 'ac_time': ac_time,
    609                 'uncorr_samples': uncorr_samples}

File /rwthfs/rz/cluster/work/ab542498/venv/phonon_contribution_pymser/pymser/src/pymser/pymser.py:301, in calc_equilibrated_average(data, eq_index, uncertainty, ac_time)
    298 # Calculate the uncorrelated Standard Error
    299 elif uncertainty == 'uSD':
    300     # Divide the equilibrated_data on uncorrelated chunks
--> 301     uncorr_batches = batch_average_data(equilibrated_data, np.ceil(ac_time).astype(int))
...
---> 90 reshaped_data = torch.reshape(truncated_data, (-1, batch_size))
     92 # Get the average of each batch
     93 averaged_batches = torch.tensor([torch.average(i) for i in reshaped_data])

TypeError: reshape(): argument 'input' (position 1) must be Tensor, not numpy.ndarray
```

which I think are related to commit [d6b9517](https://github.com/IBM/pymser/pull/6/commits/d6b9517551ca8e0b566489143b59b2b1fc1839eb). I changed some of the conversion between `numpy` and `torch` and at least the `pymser_tutorial.ipynb` now runs fine for me.

## Checklist

- [x] I ran the appropriate tests.
- [x] I ran `flake8 --max-line-length=100`.
- [x] I wrote documentation for all new features.
- [x] I have added any new dependencies (libraries and/or tools) to `setup.py`, `Pipfile` and `README.md`.

## Related Issue(s)

Closes #8 

## Notes to Reviewer

...
